### PR TITLE
Aplicación de helmetJS para la gestión de seguridad de Express y Node

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ require("dotenv").config();
 const express = require("express");
 const path = require("path");
 const cors = require("cors");
+const helmet = require("helmet");
 
 const levelRouter = require("./routes/levelRouter");
 const userRouter = require("./routes/userRouter");
@@ -17,14 +18,27 @@ app.set("view engine", "ejs");
 app.set("views", path.join(__dirname, "views"));
 
 app.use(cors());
-app.use(express.static(path.join(__dirname, "public")));
-
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+
+app.use(express.static(path.join(__dirname, "public")));
 
 app.use("/api/level", levelRouter);
 app.use("/api/user", userRouter);
 app.use("/api/group", groupRouter);
+
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      defaultSrc: ["'self'"],
+      styleSrc: ["'self'", "https://fonts.googleapis.com"],
+    },
+  })
+);
+app.disable("x-powered-by");
+app.use(helmet.frameguard({ action: "deny" }));
+app.use(helmet.xssFilter());
+app.use(helmet.hsts({ maxAge: 31536000 }));
 
 app.use((err, req, res, next) => {
   errorHandler(err, req, res, next);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "ejs": "^3.1.9",
         "express": "^4.18.2",
         "express-promise-router": "^4.1.1",
+        "helmet": "^7.1.0",
         "html": "^1.0.0",
         "http": "^0.0.1-security",
         "iconv-lite": "^0.6.3",
@@ -2662,6 +2663,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/html": {
@@ -7491,6 +7500,11 @@
       "requires": {
         "function-bind": "^1.1.2"
       }
+    },
+    "helmet": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg=="
     },
     "html": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "ejs": "^3.1.9",
     "express": "^4.18.2",
     "express-promise-router": "^4.1.1",
+    "helmet": "^7.1.0",
     "html": "^1.0.0",
     "http": "^0.0.1-security",
     "iconv-lite": "^0.6.3",


### PR DESCRIPTION
He aplicado el gestor de seguridad para Node y Express utilizando las propiedades que he visto por Internet para que nuestra aplicación sea más segura. También he comprobado en una página web cuan segura es nuestra aplicación respecto a headers, y la he subido al drive en la parte de documentación, para que cuando esté esta rama mergeada veamos si ha mejorado, en principio debería